### PR TITLE
feat(android): seed DB 同梱で CloudKit token 無しでも起動可能に (コントリビューター向け)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ Package.resolved
 
 # SQLite generated
 ImasLiveDB/Resources/master.sqlite
+# Android: db/master.sql からビルド時生成する seed (generateSeedDb タスク)
+ImasLiveDB-Android/app/src/main/assets/master_seed.sqlite
 
 # Secrets
 .env

--- a/ImasLiveDB-Android/app/build.gradle.kts
+++ b/ImasLiveDB-Android/app/build.gradle.kts
@@ -7,9 +7,10 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
-// CloudKit public read 用 API token は local.properties (git管理外) から注入する。
-// 直書き/コミットを避けつつ APK には埋め込む (public read 専用なので埋め込み可)。
-// local.properties (git管理外) を一度だけ読む。CloudKit token と署名情報を取り出す。
+// CloudKit public read 用 API token は local.properties (git管理外) / 環境変数から注入する。
+// 未設定でもアプリは起動する: 初回は db/master.sql から生成した seed DB を投入するので
+// (generateSeedDb タスク + SeedImporter)、コントリビューターは token 無しで完動できる。
+// token は「リリース版で CloudKit から最新差分を取る」ためだけに使う (未設定なら同期スキップ)。
 val localProps = Properties().apply {
     val f = rootProject.file("local.properties")
     if (f.exists()) f.inputStream().use { load(it) }
@@ -91,6 +92,26 @@ android {
         }
     }
 }
+
+// db/master.sql (monorepo の唯一の真実の源・text・diff可) から Android 同梱用の seed sqlite を
+// ビルド時に生成する。binary seed は gitignore で各自/CI が生成 (iOS の tools/build_db.sh と同じ思想)。
+// これで初回起動時に SeedImporter が実データを投入でき、コントリビューターは CloudKit token 無しで完動する。
+// dump が無い環境 (db/ を含まない clone 等) では skip し、従来通り CloudKit 同期にフォールバックする。
+val generateSeedDb by tasks.registering(Exec::class) {
+    description = "db/master.sql から Android 同梱 seed sqlite を生成"
+    val dump = rootProject.file("../db/master.sql")
+    val seed = file("src/main/assets/master_seed.sqlite")
+    onlyIf { dump.exists() }
+    inputs.file(dump).optional()
+    outputs.file(seed)
+    doFirst {
+        seed.parentFile.mkdirs()
+        seed.delete()
+    }
+    commandLine("sqlite3", seed.absolutePath, ".read ${dump.absolutePath}")
+}
+
+tasks.named("preBuild") { dependsOn(generateSeedDb) }
 
 dependencies {
     // AndroidX Core

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/MainActivity.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/MainActivity.kt
@@ -37,12 +37,13 @@ class MainActivity : ComponentActivity() {
         setContent {
             ImasLiveDBTheme {
                 val state by sync.state.collectAsState()
-                // null=判定中 / true=既存データあり / false=初回(データ無し)
+                // null=判定中 / true=データあり / false=データ無し
                 var hasData by remember { mutableStateOf<Boolean?>(null) }
                 LaunchedEffect(Unit) {
-                    hasData = sync.hasData()
-                    // 既存データありなら即UI表示してバックグラウンド差分同期。
-                    // 初回(データ無し)はフル同期完了まで下のローディングを出す。
+                    // 初回 (データ無し) は seed DB を投入してから判定する。これで CloudKit token
+                    // 未設定でも実データで起動できる (token はリリース版の最新化のためだけ)。
+                    hasData = sync.ensureLocalData()
+                    // データありなら即UI表示してバックグラウンド差分同期。
                     sync.sync()
                 }
                 val ready = hasData == true || state is CloudKitSyncEngine.SyncState.Completed

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/data/sync/CloudKitSyncEngine.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/data/sync/CloudKitSyncEngine.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 class CloudKitSyncEngine(context: Context, private val db: AppDatabase) {
 
+    private val appContext = context.applicationContext
     private val client = CloudKitClient()
-    private val prefs = context.applicationContext
-        .getSharedPreferences("imas_sync", Context.MODE_PRIVATE)
+    private val prefs = appContext.getSharedPreferences("imas_sync", Context.MODE_PRIVATE)
 
     private val _state = MutableStateFlow<SyncState>(SyncState.Idle)
     val state: StateFlow<SyncState> = _state.asStateFlow()
@@ -80,10 +80,20 @@ class CloudKitSyncEngine(context: Context, private val db: AppDatabase) {
     /** ローカルに既にデータがあるか (初回判定用)。 */
     suspend fun hasData(): Boolean = db.syncDao().brandCount() > 0
 
+    /**
+     * 起動時のローカルデータ準備: DB が空なら seed (assets/master_seed.sqlite) を投入する。
+     * 「seed = 基準データ / CloudKit = 増分」の連続したパイプラインの第1段で、ここで投入してから
+     * sync() で最新差分を当てる。投入後にデータがあるか (= UI を即表示してよいか) を返す。
+     */
+    suspend fun ensureLocalData(): Boolean = SeedImporter.importIfNeeded(appContext, db)
+
     /** 差分同期 (初回 lastSync=0 → 全件)。 */
     suspend fun sync() {
         if (!CloudKitConfig.isConfigured) {
-            _state.value = SyncState.Error("CloudKit API token が未設定です (CloudKitConfig.API_TOKEN)")
+            // token 未設定でもエラーにしない: seed DB の実データで継続する (最新化だけ行わない)。
+            // 主にコントリビューターのローカルビルド向け。リリース版は token を注入する。
+            Log.i(TAG, "CloudKit API token 未設定 → 同期スキップ (seed/既存DBで継続)")
+            _state.value = SyncState.Idle
             return
         }
         val dao = db.syncDao()

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/data/sync/SeedImporter.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/data/sync/SeedImporter.kt
@@ -1,0 +1,119 @@
+package com.fugaif.imaslivedb.data.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.fugaif.imaslivedb.data.db.AppDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * 初回起動時に、ビルド時生成した seed sqlite (assets/master_seed.sqlite) から
+ * 実データを Room DB へ投入する。
+ *
+ * iOS は db/master.sql から生成した master.sqlite をバンドルし、その上に CloudKit 差分を
+ * 当てる設計。Android も同じ思想で「seed = 基準データ / CloudKit = 増分同期」とする。
+ * これにより CloudKit API token 未設定でもアプリは実データで完動する (token はリリース版の
+ * 最新化のためだけ)。
+ *
+ * 方式: Room がスキーマの真実を握ったまま (createFromAsset のスキーマ検証クラッシュを避ける)、
+ * seed を ATTACH して「Room と seed の両方に存在するテーブル」だけを、両方に共通する列だけ
+ * INSERT OR IGNORE で行コピーする。
+ *  - song_units 等 (seed 側のみ / Room エンティティ無し) → スキップ
+ *  - user_marks / song_calls / song_videos (Room 側のみ / seed に無い) → 空のまま
+ *    (ローカル投稿・CloudKit 同期で埋まる)
+ */
+object SeedImporter {
+
+    private const val ASSET = "master_seed.sqlite"
+    private const val TAG = "SeedImporter"
+    private val SKIP_TABLES = setOf("room_master_table", "android_metadata", "sqlite_sequence")
+
+    /**
+     * DB が空 (初回) で seed asset がある時だけ投入する。冪等。
+     * 投入後にデータがあるか (UI を即表示してよいか) を返す。
+     */
+    suspend fun importIfNeeded(context: Context, db: AppDatabase): Boolean = withContext(Dispatchers.IO) {
+        if (db.syncDao().brandCount() > 0) return@withContext true  // 既に投入済み
+        if (!hasAsset(context)) {
+            Log.i(TAG, "seed asset 無し → skip (CloudKit 同期にフォールバック)")
+            return@withContext false
+        }
+
+        val tmp = File(context.cacheDir, "seed_import.sqlite")
+        try {
+            context.assets.open(ASSET).use { input ->
+                tmp.outputStream().use { input.copyTo(it, bufferSize = 64 * 1024) }
+            }
+            val sdb = db.openHelper.writableDatabase
+            // ATTACH/DETACH はトランザクション外で実行する必要がある。
+            sdb.execSQL("ATTACH DATABASE ? AS seed", arrayOf(tmp.absolutePath))
+            try {
+                val tables = commonTables(sdb)
+                sdb.beginTransaction()
+                try {
+                    for (t in tables) {
+                        val cols = commonColumns(sdb, t)
+                        if (cols.isEmpty()) continue
+                        val colList = cols.joinToString(",") { "\"$it\"" }
+                        sdb.execSQL(
+                            "INSERT OR IGNORE INTO main.\"$t\" ($colList) " +
+                                "SELECT $colList FROM seed.\"$t\""
+                        )
+                    }
+                    sdb.setTransactionSuccessful()
+                } finally {
+                    sdb.endTransaction()
+                }
+                Log.i(TAG, "seed import 完了: ${tables.size} tables")
+            } finally {
+                sdb.execSQL("DETACH DATABASE seed")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "seed import 失敗 (CloudKit 同期にフォールバック)", e)
+        } finally {
+            tmp.delete()
+        }
+        db.syncDao().brandCount() > 0  // 投入後の状態を返す
+    }
+
+    private fun hasAsset(context: Context): Boolean =
+        try {
+            context.assets.list("")?.contains(ASSET) == true
+        } catch (e: Exception) {
+            false
+        }
+
+    /** main と seed の両方に存在するテーブル名 (Room 内部テーブルは除外)。 */
+    private fun commonTables(db: SupportSQLiteDatabase): List<String> {
+        val main = tableNames(db, null)
+        val seed = tableNames(db, "seed")
+        return main.intersect(seed).filterNot { it in SKIP_TABLES }.toList()
+    }
+
+    private fun tableNames(db: SupportSQLiteDatabase, schema: String?): Set<String> {
+        val prefix = schema?.let { "$it." } ?: ""
+        val out = mutableSetOf<String>()
+        db.query("SELECT name FROM ${prefix}sqlite_master WHERE type='table'").use { c ->
+            while (c.moveToNext()) out.add(c.getString(0))
+        }
+        return out
+    }
+
+    /** main の列順を保ったまま、seed にも存在する列だけ返す。 */
+    private fun commonColumns(db: SupportSQLiteDatabase, table: String): List<String> {
+        val seed = columnNames(db, "seed", table)
+        return columnNames(db, null, table).filter { it in seed }
+    }
+
+    private fun columnNames(db: SupportSQLiteDatabase, schema: String?, table: String): List<String> {
+        val prefix = schema?.let { "$it." } ?: ""
+        val out = mutableListOf<String>()
+        db.query("PRAGMA ${prefix}table_info(\"$table\")").use { c ->
+            val idx = c.getColumnIndex("name")
+            while (c.moveToNext()) out.add(c.getString(idx))
+        }
+        return out
+    }
+}


### PR DESCRIPTION
## 目的
Android のコントリビューターが CloudKit API token 無しでも `clone → ビルド → 起動` で実データ完動できるようにする。これまでは token 未設定だと「データの取得に失敗しました」画面で詰んでいた。

## 仕組み (iOS の master.sqlite バンドルと同じ思想)
`db/master.sql`(monorepo の真実の源・text) → ビルド時に seed sqlite 生成 → 初回起動で Room に投入 → CloudKit はその上の増分同期。

- **generateSeedDb (Gradle)**: `db/master.sql` → `assets/master_seed.sqlite` をビルド時生成 (binary は gitignore・各自/CI 生成、dump 無しなら skip しフォールバック)
- **SeedImporter**: 初回起動時に seed を ATTACH し「Room と seed の両方にあるテーブル」の共通列だけ `INSERT OR IGNORE`。Room がスキーマを握るので `createFromAsset` のスキーマ検証クラッシュを回避 (`song_units`=seed側のみ→skip、`user_marks`/`song_calls`/`song_videos`=Room側のみ→空のまま)
- **CloudKitSyncEngine.ensureLocalData()**: seed 投入をデータ層に集約 (UI 層から DB/context 配線を排除)
- token 未設定時は同期を Error でなく **skip** (seed/既存DBで継続)

## 検証
- token 無しビルド (コントリビューター環境再現) で実機起動: `SeedImporter: seed import 完了: 13 tables` / `CloudKit API token 未設定 → 同期スキップ` / **エラー画面なし・クラッシュなし・実データ完動** (brands=10, songs=2594)
- importer 単体ホストテストで全ブランド投入を確認 (取りこぼしは CloudKit 同期の production 照合由来でバグでないことを確認済)
- `assembleDebug` 成功
- /simplify 4観点レビュー反映済 (brandCount 重複排除・データ層集約・copyバッファ拡大)

🤖 Generated with [Claude Code](https://claude.com/claude-code)