### PR TITLE
DELETE /users/me で本人アカウントを削除できるように

### DIFF
--- a/imas-live-api/src/index.ts
+++ b/imas-live-api/src/index.ts
@@ -957,6 +957,65 @@ export default {
       }
 
       // ----------------------------------------------------------------
+      // DELETE /users/me — 本人によるアカウント削除 (App Store 5.1.1(v) 対応)
+      //   退会を妨げないため BAN 中でも許可する。リクエストボディは無い。
+      //   ログインで初めて作られるアカウント紐付けデータ (投票・like・編集履歴・Good) は
+      //   すべて物理削除する。Good 数や like 数は保存値ではなく都度 COUNT(*) なので、
+      //   本人の行を消せば表示カウントも自然に減る。予想/投票の集計テーブル (vote_count 等) は
+      //   端末・匿名の共有データなので触らない。
+      //   foreign_keys が ON でも通るよう、子テーブルの参照を先に外してから親 → users の順に消す。
+      //   一連の操作は env.DB.batch() で原子的に実行し、途中失敗で中途半端な状態を残さない。
+      // ----------------------------------------------------------------
+      if (path === "/users/me" && request.method === "DELETE") {
+        const user = await getAuthUser(request, env);
+        if (!user) return error("Unauthorized", 401);
+        const uid = user.uid;
+
+        await env.DB.batch([
+          // 本人だけに紐づく個人データ。FK は無いのでそのまま削除する。
+          env.DB.prepare("DELETE FROM rate_limits WHERE user_id = ?").bind(uid),
+          env.DB.prepare("DELETE FROM setlist_prediction_votes WHERE user_id = ?").bind(uid),
+          env.DB
+            .prepare("DELETE FROM setlist_performer_prediction_votes WHERE user_id = ?")
+            .bind(uid),
+          env.DB.prepare("DELETE FROM poll_votes WHERE user_id = ?").bind(uid),
+          env.DB.prepare("DELETE FROM setlist_song_likes WHERE user_id = ?").bind(uid),
+
+          // Good は本人が付けた分と、本人の編集が受け取った分の双方を削除する。
+          // edit_batch を消す前に、それを参照する edit_good を先に消す (FK)。
+          env.DB.prepare("DELETE FROM edit_good WHERE user_id = ?").bind(uid),
+          env.DB
+            .prepare(
+              "DELETE FROM edit_good WHERE batch_id IN (SELECT id FROM edit_batch WHERE editor_id = ?)"
+            )
+            .bind(uid),
+
+          // edit_history も edit_batch を参照するので先に消す (FK)。
+          env.DB
+            .prepare(
+              "DELETE FROM edit_history WHERE batch_id IN (SELECT id FROM edit_batch WHERE editor_id = ?)"
+            )
+            .bind(uid),
+
+          // 他者の batch に残る本人の batch / 本人への参照を外す (FK)。
+          //   reverts_batch_id: 本人の編集を revert した他者 batch から、消える batch への参照を外す
+          //   reverted_by:      本人が他者の編集を revert した記録の実行者参照を外す
+          env.DB
+            .prepare(
+              "UPDATE edit_batch SET reverts_batch_id = NULL WHERE reverts_batch_id IN (SELECT id FROM edit_batch WHERE editor_id = ?)"
+            )
+            .bind(uid),
+          env.DB.prepare("UPDATE edit_batch SET reverted_by = NULL WHERE reverted_by = ?").bind(uid),
+
+          // 参照を外したので本人の編集 batch を削除し、最後に users 行を削除する。
+          env.DB.prepare("DELETE FROM edit_batch WHERE editor_id = ?").bind(uid),
+          env.DB.prepare("DELETE FROM users WHERE id = ?").bind(uid),
+        ]);
+
+        return json({ deleted: true });
+      }
+
+      // ----------------------------------------------------------------
       // POST /admin/cloudkit/save — admin 限定の CK forceUpdate+delete
       // iOS 直書きでは「他人 (S2S) のレコードを更新不可」なのでサーバ経由で S2S 借用。
       // ----------------------------------------------------------------


### PR DESCRIPTION
iOS の AuthService.deleteAccount() が呼ぶ DELETE /users/me を実装する。 App Store Guideline 5.1.1(v) のアカウント削除要件に対応するもので、サーバ側のみの変更。

ログインで初めて作られるアカウント紐付けデータ (rate_limits / 予想投票 / poll_votes / setlist_song_likes / 編集 batch・履歴・Good) をすべて物理削除する。Good 数や like 数は 保存値ではなく都度 COUNT(*) なので、本人の行を消せば表示カウントも自然に減る。予想/投票の 集計テーブル (vote_count 等) は匿名の共有データなので触らない。foreign_keys が ON でも通るよう、 edit_history / edit_good を先に消し、他者の batch に残る reverts_batch_id / reverted_by の参照を NULL 化してから edit_batch を消し、最後に users を削除する。一連の操作は env.DB.batch() で 原子的に実行する。BAN 中でも退会を妨げないため許可する。

setlist_song_likes は user_id 紐付けの個人データだが既存コードと同様にリモート DB の 既存テーブルを前提とする (この PR ではスキーマ定義は追加しない)。

## 確認したこと

ローカル (wrangler dev + D1、foreign_keys=1) で curl 検証した。

- 認証あり DELETE: 200、本人の全テーブルの行が消え users も消える
- 別ユーザーのデータは保全。他者から受け取った Good 数も保たれる
- revert チェーンの参照 (reverts_batch_id / reverted_by) が NULL になる
- 認証なし: 401
- 削除済みトークンで再 DELETE: 200 (冪等)、再 /auth/me: 200 で displayName 等が null
- BAN 中ユーザーでも削除できる


## 実機確認

curl だけでなく、ローカルの wrangler dev (Miniflare + ローカル D1、foreign_keys=1) に実機を同一 LAN で繋ぎ、実際のアプリ操作で end-to-end も確認した。

- アプリで Sign in with Apple してログイン
- セトリ画面で曲を 11 件いいね (setlist_song_likes に user_id 紐付けで記録されるのを確認)
- マイページからアカウント削除 → DELETE /users/me 200

削除後にローカル D1 を照合:

- 本人の users 行が消え、他の 2 ユーザーは残る
- 本人の setlist_song_likes 11 件と rate_limits が消える
- 別ユーザーの like は無傷 (like 合計が 12 → 1 に減る)
- 端末ひも付けの device_song_favorite は退会後も残る (user_id 紐付けではないため。意図どおり)