### PR TITLE
fix:[Android] リードバーにブランドカラーを反映

### DIFF
--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/components/ImasComponents.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/components/ImasComponents.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.SubcomposeAsyncImage
 import com.fugaif.imaslivedb.data.model.Idol
+import com.fugaif.imaslivedb.ui.theme.BrandPalette
 import com.fugaif.imaslivedb.ui.theme.DS
 import com.fugaif.imaslivedb.ui.theme.ImasTheme
 
@@ -141,9 +142,19 @@ private fun ArtworkFallback(title: String, t: ImasTheme, size: Dp) {
     }
 }
 
-/** 一覧の控えめなエンティティ色マーカー (行頭の細い縦バー)。 */
+/**
+ * 一覧の控えめなエンティティ色マーカー (行頭の細い縦バー)。
+ *
+ * [seedHex] はエンティティ固有色。[brandId] は [BrandPalette] のブランド色へ解決し、
+ * seedが無い場合のフォールバックとして使う。
+ */
 @Composable
-fun ImasLeadBar(seed: String? = null, brand: String? = null, height: Dp = 40.dp, rainbow: Boolean = false) {
+fun ImasLeadBar(
+    seedHex: String? = null,
+    brandId: String? = null,
+    height: Dp = 40.dp,
+    rainbow: Boolean = false
+) {
     val background = if (rainbow) {
         androidx.compose.ui.graphics.Brush.verticalGradient(
             listOf(
@@ -152,7 +163,7 @@ fun ImasLeadBar(seed: String? = null, brand: String? = null, height: Dp = 40.dp,
             )
         )
     } else {
-        val t = ImasTheme.derive(seed, brand, dark = true)
+        val t = ImasTheme.derive(seedHex, BrandPalette.hex(brandId), dark = true)
         androidx.compose.ui.graphics.SolidColor(t.bar)
     }
     Box(

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/components/SongRow.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/components/SongRow.kt
@@ -59,7 +59,7 @@ fun SongRow(
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
     ) {
-        ImasLeadBar(brand = brandId, height = 44.dp)
+        ImasLeadBar(brandId = brandId, height = 44.dp)
         ArtworkImage(url = artworkUrl, size = 44.dp, previewUrl = previewUrl, songTitle = title)
         Column(modifier = Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/events/EventDetailScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/events/EventDetailScreen.kt
@@ -321,7 +321,7 @@ private fun ShowRow(show: Show, seed: String?, brand: String?, rainbow: Boolean,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        ImasLeadBar(seed = seed, brand = brand, height = 36.dp, rainbow = rainbow)
+        ImasLeadBar(seedHex = seed ?: brand, height = 36.dp, rainbow = rainbow)
         Column(Modifier.weight(1f)) {
             Text(
                 show.name, fontSize = 15.sp, fontWeight = FontWeight.SemiBold, color = DS.ink,

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/events/EventListScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/events/EventListScreen.kt
@@ -222,7 +222,7 @@ private fun EventRow(
             .padding(horizontal = 16.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        ImasLeadBar(brand = event.brandId, height = 38.dp, rainbow = isJoint)
+        ImasLeadBar(brandId = event.brandId, height = 38.dp, rainbow = isJoint)
 
         Column(modifier = Modifier.weight(1f)) {
             Text(

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/idols/IdolListScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/idols/IdolListScreen.kt
@@ -341,7 +341,7 @@ private fun IdolRow(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        ImasLeadBar(seed = idol.color, brand = idol.brandId, height = 36.dp)
+        ImasLeadBar(seedHex = idol.color, brandId = idol.brandId, height = 36.dp)
         Box(Modifier.padding(start = 8.dp)) {
             ImasAvatar(label = idol.name, seed = idol.color, brand = idol.brandId, size = 40.dp, isPick = isPick)
         }

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/mypage/AttendedEventsScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/mypage/AttendedEventsScreen.kt
@@ -164,7 +164,7 @@ fun AttendedEventsScreen(
                                 .clickable { onEventClick(ew.event.id) }
                                 .padding(horizontal = 16.dp, vertical = 10.dp)
                         ) {
-                            ImasLeadBar(brand = ew.event.brandId, height = 38.dp, rainbow = ew.event.jointBrandIdList.isNotEmpty())
+                            ImasLeadBar(brandId = ew.event.brandId, height = 38.dp, rainbow = ew.event.jointBrandIdList.isNotEmpty())
                             Column(Modifier.weight(1f)) {
                                 Text(
                                     text = ew.event.name,

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/mypage/FavoritesScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/mypage/FavoritesScreen.kt
@@ -198,7 +198,7 @@ private fun EventsTab(events: List<EventWithDateRange>) {
                 horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp),
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp)
             ) {
-                ImasLeadBar(brand = ew.event.brandId, height = 38.dp, rainbow = ew.event.jointBrandIdList.isNotEmpty())
+                ImasLeadBar(brandId = ew.event.brandId, height = 38.dp, rainbow = ew.event.jointBrandIdList.isNotEmpty())
                 Column(Modifier.weight(1f)) {
                     Text(
                         text = ew.event.name,

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/search/SearchScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/search/SearchScreen.kt
@@ -280,7 +280,7 @@ private fun SongSearchRow(song: Song, onClick: () -> Unit) {
 @Composable
 private fun EventSearchRow(event: Event, onClick: () -> Unit) {
     SearchRow(onClick = onClick, lead = {
-        ImasLeadBar(brand = event.brandId, height = 32.dp)
+        ImasLeadBar(brandId = event.brandId, height = 32.dp)
     }, title = event.name, subtitle = null)
 }
 

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/songs/SongDetailScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/songs/SongDetailScreen.kt
@@ -728,7 +728,7 @@ private fun HistoryTab(history: List<PerformanceHistoryRow>, seed: String?, bran
                     .padding(horizontal = 16.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                ImasLeadBar(seed = seed, brand = brand, height = 34.dp)
+                ImasLeadBar(seedHex = seed, brandId = brand, height = 34.dp)
                 Column(Modifier.weight(1f).padding(start = 12.dp)) {
                     Text(row.eventName, fontSize = 15.sp, fontWeight = FontWeight.SemiBold, color = DS.ink,
                         maxLines = 1, overflow = TextOverflow.Ellipsis)

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/stats/StatsScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/stats/StatsScreen.kt
@@ -282,7 +282,7 @@ private fun CatchChanceCard(chance: UpcomingCatchChance, onClick: () -> Unit) {
             .padding(20.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        ImasLeadBar(brand = chance.brandId, height = 56.dp)
+        ImasLeadBar(brandId = chance.brandId, height = 56.dp)
         Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text("${displayDate(chance.show.date)} ・ ${chance.eventName}", fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = DS.ink3, maxLines = 1)
             Text(chance.show.name, fontSize = 17.sp, fontWeight = FontWeight.Bold, color = DS.ink, maxLines = 2)
@@ -399,7 +399,7 @@ private fun LatestShowCard(show: com.fugaif.imaslivedb.data.model.Show, songCoun
             .padding(20.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        ImasLeadBar(seed = brandColor, height = 64.dp)
+        ImasLeadBar(seedHex = brandColor, height = 64.dp)
         Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text("最新公演 ・ ${displayDate(show.date)}", fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = DS.ink3)
             Text(show.name, fontSize = 17.sp, fontWeight = FontWeight.Bold, color = DS.ink, maxLines = 2)

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/theme/BrandPalette.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/theme/BrandPalette.kt
@@ -1,0 +1,19 @@
+package com.fugaif.imaslivedb.ui.theme
+
+// iOS の `BrandPalette` および master.sqlite の `brands.color` と一致させる。
+object BrandPalette {
+    private val colors = mapOf(
+        "765as" to "#fe0000",
+        "961" to "#520000",
+        "876" to "#656a75",
+        "cg" to "#2681c8",
+        "ml" to "#ffc30b",
+        "sidem" to "#0fbe94",
+        "sc" to "#6bb6b9",
+        "gakuen" to "#f39800",
+        "other" to "#8e8e93"
+    )
+
+    /** 既知ブランドのhex。未知またはnullならnull。 */
+    fun hex(brandId: String?): String? = colors[brandId]
+}

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/theme/Color.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/theme/Color.kt
@@ -31,17 +31,6 @@ object DS {
     val favorite = Color(0xFFFFC83E)
 }
 
-// Brand color constants
-val Brand765AS = Color(0xFFFE0000)
-val Brand961 = Color(0xFF520000)
-val Brand876 = Color(0xFF6EC6C8)
-val BrandCG = Color(0xFF2681C8)
-val BrandML = Color(0xFFFFC30B)
-val BrandSideM = Color(0xFF0FBE94)
-val BrandSC = Color(0xFF6BB6B9)
-val BrandGakuen = Color(0xFFFF6699)
-val BrandValiv = Color(0xFF7F51DC)
-
 /**
  * Convert a hex color string (with or without leading #) to a Compose Color.
  * Returns Color.Gray on parse failure.
@@ -61,15 +50,5 @@ fun hexToColor(hex: String): Color {
 }
 
 /** Return the brand color for a given brandId string, or Gray if unknown. */
-fun brandColor(brandId: String?): Color = when (brandId) {
-    "765as" -> Brand765AS
-    "961" -> Brand961
-    "876" -> Brand876
-    "cg" -> BrandCG
-    "ml" -> BrandML
-    "sidem" -> BrandSideM
-    "sc" -> BrandSC
-    "gakuen" -> BrandGakuen
-    "valiv" -> BrandValiv
-    else -> Color.Gray
-}
+fun brandColor(brandId: String?): Color =
+    BrandPalette.hex(brandId)?.let(::hexToColor) ?: Color.Gray

--- a/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/units/UnitListScreen.kt
+++ b/ImasLiveDB-Android/app/src/main/kotlin/com/fugaif/imaslivedb/ui/units/UnitListScreen.kt
@@ -170,7 +170,7 @@ private fun UnitRow(unit: ImasUnit, onClick: () -> Unit) {
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        ImasLeadBar(seed = unit.id, brand = unit.brandId, height = 36.dp)
+        ImasLeadBar(brandId = unit.brandId, height = 36.dp)
         Box(Modifier.padding(start = 8.dp)) {
             ImasAvatar(label = unit.name, seed = unit.id, brand = unit.brandId, size = 40.dp)
         }


### PR DESCRIPTION
Closes #81

## 概要

Android版の各一覧で、リードバーにブランドカラーが反映されるよう修正します。

## 原因

`ImasTheme.derive` はhexカラーを受け取るAPIですが、複数の`ImasLeadBar`呼び出し箇所から`brand_id`をそのまま渡していました。

そのため、通常のブランドIDは無効な色としてニュートラルカラーへフォールバックし、`876`や`961`は3桁hexとして解釈されていました。

## 変更内容

- iOS版と`master.sqlite`に合わせた`BrandPalette`をAndroid版へ追加
- `ImasLeadBar`の引数を`seedHex`と`brandId`に分離
- ライブ、楽曲、アイドル、ユニット、検索、統計などの呼び出し箇所を新しいAPIへ移行
- 既存の`brandColor()`も`BrandPalette`を参照するよう統一

単一ブランドでは正しいブランドカラーを表示し、合同ライブの虹色表示と未知ブランドのニュートラルカラーへのフォールバックは維持します。

## 動作確認スクショ

<img width="520" height="1200" alt="Screenshot_1785252447" src="https://github.com/user-attachments/assets/966b03fa-3e2c-4c41-b3dc-11d64554a337" />




