### PR TITLE
Nix Flakeの追加

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/ImasLiveDB-Android/.envrc
+++ b/ImasLiveDB-Android/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/ImasLiveDB-Android/flake.lock
+++ b/ImasLiveDB-Android/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784453100,
+        "narHash": "sha256-zpGZb8FYui+i8KLtC0nlcmb0voR2zB80Qn8pe7lzIbk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b471514bed69eff5255c8e63c1f80e5fe56c616f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/ImasLiveDB-Android/flake.nix
+++ b/ImasLiveDB-Android/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "ImasLiveDB Android devShell";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    { self, ... }@inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+
+      perSystem =
+        { system, ... }:
+        let
+          pkgs = import inputs.nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
+
+          # Android SDK composition (SDK 35, build-tools 35.0.0, + emulator + system image)
+          androidSdk = (pkgs.androidenv.override { licenseAccepted = true; }).composeAndroidPackages {
+            platformVersions = [ "35" ];
+            buildToolsVersions = [ "35.0.0" ];
+            includeEmulator = true;
+            includeSystemImages = true;
+            abiVersions = [ "x86_64" ];
+          };
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            packages = [
+              pkgs.jdk17
+              androidSdk.androidsdk
+              pkgs.kotlin-language-server
+            ];
+
+            CLOUDKIT_API_TOKEN = "";
+
+            shellHook = ''
+              export ANDROID_HOME=${androidSdk.androidsdk}/libexec/android-sdk
+              export ANDROID_SDK_ROOT=${androidSdk.androidsdk}/libexec/android-sdk
+              export JAVA_HOME=${pkgs.jdk17}
+              export GRADLE_USER_HOME=$(pwd)/.gradle
+              echo "🍀 Android devShell activated"
+              echo "   ANDROID_HOME=$ANDROID_HOME"
+              echo "   JAVA_HOME=$JAVA_HOME"
+            '';
+          };
+        };
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
         "nixpkgs-python39": "nixpkgs-python39"
       },
       "locked": {
-        "lastModified": 1785670258,
-        "narHash": "sha256-SbsXCb0BxvewaBhaseRRWMJQpn6T+0MBe1tCC2ro/Os=",
+        "lastModified": 1786400021,
+        "narHash": "sha256-h8YCsFRfNf7Z4IkS4Zdcvp8Xxf4EWfsgU2vIJuZSHFs=",
         "owner": "Comamoca",
         "repo": "swift-overlay",
-        "rev": "5908f438683a63a539c5747119dff7dcbcf92505",
+        "rev": "88226470748e36e6137491c76512345881c58ea7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784453100,
-        "narHash": "sha256-zpGZb8FYui+i8KLtC0nlcmb0voR2zB80Qn8pe7lzIbk=",
+        "lastModified": 1785301185,
+        "narHash": "sha256-eoS3KQTO0aPWXZvIaRbRAzSSHW3l5wdMFXtT1ISfoKA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b471514bed69eff5255c8e63c1f80e5fe56c616f",
+        "rev": "9bc02893134c733dd85de46ee4fb2fac696b5529",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,63 @@
         "type": "github"
       }
     },
+    "nixpkgs-python39": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "swift-overlay": "swift-overlay",
         "systems": "systems"
+      }
+    },
+    "swift-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-python39": "nixpkgs-python39"
+      },
+      "locked": {
+        "lastModified": 1785670258,
+        "narHash": "sha256-SbsXCb0BxvewaBhaseRRWMJQpn6T+0MBe1tCC2ro/Os=",
+        "owner": "Comamoca",
+        "repo": "swift-overlay",
+        "rev": "5908f438683a63a539c5747119dff7dcbcf92505",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Comamoca",
+        "repo": "swift-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784453100,
+        "narHash": "sha256-zpGZb8FYui+i8KLtC0nlcmb0voR2zB80Qn8pe7lzIbk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b471514bed69eff5255c8e63c1f80e5fe56c616f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "ImasLiveDB development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    { self, ... }@inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+
+      perSystem =
+        { pkgs, ... }:
+        let
+          # Cross-platform Swift ツール (Linux / macOS 両方で使える)
+          swiftPkgs = with pkgs; [
+            swift           # コンパイラ (nixpkgs は 5.10.1)
+            swiftpm         # Swift Package Manager
+            sourcekit-lsp   # LSP (コード補完・診断)
+            swift-format    # フォーマッター
+            swiftlint       # 静的解析
+          ];
+
+          # macOS 専用ツール (Xcode 依存)
+          macOnlyPkgs = with pkgs; [
+            xcodegen        # Xcode プロジェクト生成 (project.yml → .xcodeproj)
+          ];
+
+          # 全プラットフォーム向け共通ツール
+          commonPkgs = with pkgs; [
+            nodejs
+            python3
+            sqlite
+            nixd
+            typescript-language-server
+          ];
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            packages = commonPkgs
+              ++ swiftPkgs
+              ++ pkgs.lib.optionals pkgs.stdenv.isDarwin macOnlyPkgs;
+
+            shellHook = ''
+              echo "🍀 ImasLiveDB devShell activated"
+              echo "   Platform : ${pkgs.stdenv.system}"
+              echo "   Node.js  : $(node --version 2>/dev/null || echo 'N/A')"
+              echo "   Python   : $(python3 --version 2>/dev/null || echo 'N/A')"
+              echo "   SQLite   : $(sqlite3 --version 2>/dev/null || echo 'N/A')"
+              echo "   Swift    : $(swift --version 2>/dev/null | head -1 || echo 'N/A')"
+              ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+                echo "   XcodeGen : $(xcodegen --version 2>/dev/null || echo 'N/A')"
+              ''}
+            '';
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,24 +5,31 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
+    swift-overlay.url = "github:Comamoca/swift-overlay";
   };
 
   outputs =
     { self, ... }@inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import inputs.systems;
+      # swift-overlay の対応システムに合わせる (x86_64-darwin は overlay が廃止)
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
 
       perSystem =
-        { pkgs, ... }:
+        { pkgs, system, ... }:
         let
           # Cross-platform Swift ツール (Linux / macOS 両方で使える)
-          swiftPkgs = with pkgs; [
-            swift           # コンパイラ (nixpkgs は 5.10.1)
-            swiftpm         # Swift Package Manager
-            sourcekit-lsp   # LSP (コード補完・診断)
-            swift-format    # フォーマッター
-            swiftlint       # 静的解析
-          ];
+          # swift.bin.latest は swift-overlay が提供 (Swift 6.3.3)
+          # swiftpm / sourcekit-lsp / swift-format は Swift 6.3.3 配布物に同梱されているため、
+          # nixpkgs 版を入れると Swift 5.x のビルドがトリガーされるので使わない。
+          swiftPkgs = [
+            inputs.swift-overlay.packages.${system}.default   # Swift 6.3.3 (swift, swift-format, sourcekit-lsp, swift-package 等同梱)
+          ] ++ (with pkgs; [
+            swiftlint                                         # 静的解析 (pre-built binary, Swift 5 をビルドしない)
+          ]);
 
           # macOS 専用ツール (Xcode 依存)
           macOnlyPkgs = with pkgs; [


### PR DESCRIPTION
## 概要
環境構築用のNix Flakeファイルを追加します。

## 背景
android sdkやswiftは様々なソフトウェアに依存しており、環境構築の難易度が高いです。
しかし、Nixを用いることで再現性のある開発環境を提供でき、環境構築の難易度を下げることが期待できます。

## 追加した変更
以下の2箇所に`flake.nix`ファイルを追加しています。

- flake.nix
- .envrc
- ImasLiveDB-Android/flake.nix
- ImasLiveDB-Android/.envrc

プロジェクトルートの`flake.nix`では`imas-live-api`と`ImasLiveDB`向けの環境を定義しています。
`ImasLiveDB-Android/flake.nix`ではAndroidアプリ開発向けの環境を定義しています。

## 利用方法
`nix develop`を実行すると開発環境に入れます。
また、[direnv](https://github.com/direnv/direnv)を導入している場合は自動で`nix develop`が実行され、普段利用しているshellで開発環境に入ることができます。

## swiftのLinuxサポートについて
今回追加したflakeではswiftを提供しています。
しかし、Nixのswiftパッケージは現状満足にサポートされているとは言えず、Linuxにおいてはパッケージのビルドが失敗しつづけているという状況が続いています。
そこで、今回のPRでは独自に作成したビルドレシピ[swift-overlay](https://github.com/comamoca/swift-overlay)を使用してLinux版のswiftをサポートしています。
 Nixはソースコードからビルドするのが一般的ですが、[swift-overlay](https://github.com/comamoca/swift-overlay)では暫定的にバイナリパッケージにパッチを当てたものを使用しています。
これはNixの観点から見るとパッケージの信頼性を損ねるという点がありますが、swiftのビルドにはsiwftが必要であることと、ビルドに必要なswiftパッケージの入手が難しいことから、このような手法を採用しています。

説明が長くなりましたが、Nix本来の考え方に則ったパッケージング方法ではないものの、単に環境構築の用途で使用する際は問題ないという認識です。

## 特記事項
- ~~flakeについて、darwin環境でも動くように作成しましたが、現在使用できる環境がLinuxのみなため、darwinでの動作が確認できていません。
 そのため、PRをmergeする前にdarwinでも使用可能か動作確認をお願いします。~~ 動作確認をし、発生したエラーも修整済みの状態になっています。
- 開発環境は複数人で使用するため、ビルド結果をcacheすると便利です。人数が増えてきた際は[cachix](https://www.cachix.org/)等でビルドキャッシュを公開することを検討してください。