### PR TITLE
data(live): 2026年8月公演のセトリ6本と新曲5曲 + cron の meta 消失を直す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ CLAUDE.md
 
 # xcodegen/実行時に生成される空の作業用 DB (正は db/master.sql)
 db/master.sqlite
+
+# tools/ の Python スクリプトを import/実行したときに出るバイトコード
+__pycache__/
+*.pyc

--- a/data/events/20260809_miki_hoshii_showcase_korea.json
+++ b/data/events/20260809_miki_hoshii_showcase_korea.json
@@ -1,0 +1,28 @@
+{
+  "title": "MIKI HOSHII SOLO SHOWCASE「THE FUTURE SPOTLIGHT」in KOREA (2026-08-09) の追加",
+  "_help": "KIMCHIKURA Fes '26 出演記念の韓国公演。星井美希海外ライブ第2弾 (シカゴ公演に続く)",
+  "source": "https://idolmaster-official.jp/news/01_19478",
+  "events": [
+    {
+      "id": "ev_miki_hoshii_solo_showcase_the_future_spotlight_in_korea",
+      "brand_id": "765as",
+      "name": "MIKI HOSHII SOLO SHOWCASE「THE FUTURE SPOTLIGHT」in KOREA",
+      "event_type": "live",
+      "kind": "live",
+      "is_streaming": 0,
+      "is_solo": 0,
+      "ticket_url": "https://www.ticketlink.co.kr/global/ja/product/64625",
+      "shows": [
+        {
+          "id": "sh_miki_hoshii_solo_showcase_the_future_spotlight_in_korea_1",
+          "name": "MIKI HOSHII SOLO SHOWCASE「THE FUTURE SPOTLIGHT」in KOREA",
+          "date": "2026-08-09",
+          "venue": "Gabin Art Hall (ソウル / 韓国)",
+          "venue_city": "ソウル",
+          "start_time": "17:30",
+          "sort_order": 1
+        }
+      ]
+    }
+  ]
+}

--- a/data/setlists/20260806_dual_twin_futagoboshi_osaka.json
+++ b/data/setlists/20260806_dual_twin_futagoboshi_osaka.json
@@ -1,0 +1,105 @@
+{
+  "title": "dual twin live tour 双海 亜美・双海 真美 twin live “ふたごぼしのつばさ” [ワクワクフタリボシ] (2026-08-06 Zepp Namba) セットリスト",
+  "show_id": "sh_765pro_allstars_dual_twin_live_tour_ふたごぼしのつばさ_つみまつよるまち_1",
+  "all_performers": [
+    "765as_双海亜美",
+    "765as_双海真美"
+  ],
+  "source": "https://idolmaster-official.jp/news/01_19563",
+  "_sources": [
+    "https://idolmaster-official.jp/news/01_19563",
+    "https://aimasupay.hatenablog.com/entry/2026/08/06/215620"
+  ],
+  "songs": [
+    {
+      "position": 1,
+      "song_id": "765as_スタトスタ",
+      "performers": "all"
+    },
+    {
+      "position": 2,
+      "song_id": "765as_ドキッラブアトラクション",
+      "performers": "all"
+    },
+    {
+      "position": 3,
+      "song_id": "ml_オンステージプレーヤー",
+      "performers": "all"
+    },
+    {
+      "position": 4,
+      "song_id": "765as_紅白応援v_ビクトリー",
+      "performers": "all"
+    },
+    {
+      "position": 5,
+      "song_id": "765as_おとなのはじまり",
+      "performers": "all"
+    },
+    {
+      "position": 6,
+      "song_id": "765as_ビジョナリー",
+      "performers": "all"
+    },
+    {
+      "position": 7,
+      "song_id": "ml_ジャングルパーティー",
+      "performers": "all"
+    },
+    {
+      "position": 8,
+      "song_id": "765as_pon_de_beach",
+      "performers": [
+        "765as_双海亜美"
+      ]
+    },
+    {
+      "position": 9,
+      "song_id": "765as_エージェント夜を往く",
+      "performers": "all"
+    },
+    {
+      "position": 10,
+      "song_id": "765as_トリプルangel",
+      "performers": [
+        "765as_双海真美"
+      ]
+    },
+    {
+      "position": 11,
+      "song_id": "765as_放課後ジャンプ",
+      "performers": "all"
+    },
+    {
+      "position": 12,
+      "song_id": "765as_you往my進",
+      "performers": "all"
+    },
+    {
+      "position": 13,
+      "song_id": "765as_キラメキラリ",
+      "performers": "all"
+    },
+    {
+      "position": 14,
+      "song_id": "765as_黎明スターライン",
+      "performers": "all"
+    },
+    {
+      "position": 15,
+      "song_id": "765as_北極星をズラしちゃえ",
+      "performers": "all",
+      "notes": "新曲初披露 (会場オリジナルCD SACX-1140 表題曲)"
+    },
+    {
+      "position": 16,
+      "song_id": "765as_ポジティブ",
+      "performers": "all"
+    },
+    {
+      "position": 17,
+      "song_id": "765as_そしてぼくらは旅にでる",
+      "performers": "all"
+    }
+  ]
+}

--- a/data/setlists/20260807_dual_twin_tsumimatsu_osaka.json
+++ b/data/setlists/20260807_dual_twin_tsumimatsu_osaka.json
@@ -1,0 +1,119 @@
+{
+  "title": "dual twin live tour 三浦 あずさ・秋月 律子 twin live “つみまつよるまち” [OSAKA SILENTCITY LOVE] (2026-08-07 Zepp Namba) セットリスト",
+  "show_id": "sh_765pro_allstars_dual_twin_live_tour_ふたごぼしのつばさ_つみまつよるまち_2",
+  "all_performers": [
+    "765as_三浦あずさ",
+    "765as_秋月律子"
+  ],
+  "source": "https://idolmaster-official.jp/news/01_19572",
+  "_sources": [
+    "https://idolmaster-official.jp/news/01_19572",
+    "https://x.com/imas_official/status/2085697486493200604",
+    "https://aimasupay.hatenablog.com/entry/2026/08/07/233417",
+    "https://panora.tokyo/archives/152535"
+  ],
+  "_note": "曲間に朗読 (ポエトリー) パートあり",
+  "songs": [
+    {
+      "position": 1,
+      "song_id": "765as_902pm",
+      "performers": [
+        "765as_三浦あずさ"
+      ]
+    },
+    {
+      "position": 2,
+      "song_id": "765as_crimson_lovers",
+      "performers": "all"
+    },
+    {
+      "position": 3,
+      "song_id": "765as_inferno_squaring",
+      "performers": [
+        "765as_三浦あずさ"
+      ]
+    },
+    {
+      "position": 4,
+      "song_id": "765as_アイシテの呪縛je_vous_aime",
+      "performers": "all"
+    },
+    {
+      "position": 5,
+      "song_id": "ml_嘆きのfraction",
+      "performers": [
+        "765as_三浦あずさ"
+      ]
+    },
+    {
+      "position": 6,
+      "song_id": "961_kiss",
+      "performers": "all"
+    },
+    {
+      "position": 7,
+      "song_id": "765as_dream",
+      "performers": [
+        "765as_秋月律子"
+      ]
+    },
+    {
+      "position": 8,
+      "song_id": "765as_mythmaker",
+      "performers": [
+        "765as_三浦あずさ"
+      ]
+    },
+    {
+      "position": 9,
+      "song_id": "765as_live",
+      "performers": "all",
+      "notes": "三浦あずさが1番を歌唱し、2番から秋月律子が参加"
+    },
+    {
+      "position": 10,
+      "song_id": "765as_arcadia",
+      "performers": "all"
+    },
+    {
+      "position": 11,
+      "song_id": "ml_discord_area",
+      "performers": [
+        "765as_秋月律子"
+      ]
+    },
+    {
+      "position": 12,
+      "song_id": "765as_lost",
+      "performers": [
+        "765as_三浦あずさ"
+      ]
+    },
+    {
+      "position": 13,
+      "song_id": "765as_new_me_continued",
+      "performers": "all"
+    },
+    {
+      "position": 14,
+      "song_id": "ml_i_do",
+      "performers": [
+        "765as_三浦あずさ"
+      ]
+    },
+    {
+      "position": 15,
+      "song_id": "765as_隣に",
+      "performers": [
+        "765as_三浦あずさ"
+      ],
+      "notes": "三浦あずさがロングヘアで歌唱"
+    },
+    {
+      "position": 16,
+      "song_id": "765as_binary_star",
+      "performers": "all",
+      "notes": "新曲初披露 (会場オリジナルCD SACX-1139 表題曲)"
+    }
+  ]
+}

--- a/data/setlists/20260813_dual_twin_futagoboshi_nagoya.json
+++ b/data/setlists/20260813_dual_twin_futagoboshi_nagoya.json
@@ -1,0 +1,113 @@
+{
+  "title": "dual twin live tour 双海 亜美・双海 真美 twin live “ふたごぼしのつばさ” [ソワソワフタリボシ] (2026-08-13 Zepp Nagoya) セットリスト",
+  "show_id": "sh_765pro_allstars_dual_twin_live_tour_ふたごぼしのつばさ_つみまつよるまち_3",
+  "all_performers": [
+    "765as_双海亜美",
+    "765as_双海真美"
+  ],
+  "source": "https://aimasupay.hatenablog.com/entry/2026/08/14/081831",
+  "_sources": [
+    "https://aimasupay.hatenablog.com/entry/2026/08/14/081831",
+    "https://idolmaster-official.jp/live_event/765as_dualtwin/"
+  ],
+  "_note": "大阪公演 (ワクワクフタリボシ) との共通曲は8曲、9曲が入れ替わり",
+  "songs": [
+    {
+      "position": 1,
+      "song_id": "765as_黎明スターライン",
+      "performers": "all"
+    },
+    {
+      "position": 2,
+      "song_id": "765as_ドキッラブアトラクション",
+      "performers": "all"
+    },
+    {
+      "position": 3,
+      "song_id": "ml_ユニークスタープレイヤー",
+      "performers": [
+        "765as_双海真美"
+      ]
+    },
+    {
+      "position": 4,
+      "song_id": "765as_北極星をズラしちゃえ",
+      "performers": "all"
+    },
+    {
+      "position": 5,
+      "song_id": "ml_ジャングルパーティー",
+      "performers": "all"
+    },
+    {
+      "position": 6,
+      "song_id": "765as_pon_de_beach",
+      "performers": "all"
+    },
+    {
+      "position": 7,
+      "song_id": "765as_エージェント夜を往く",
+      "performers": "all"
+    },
+    {
+      "position": 8,
+      "song_id": "765as_おとなのはじまり",
+      "performers": "all"
+    },
+    {
+      "position": 9,
+      "song_id": "765as_セクシータイフーン",
+      "performers": [
+        "765as_双海真美"
+      ]
+    },
+    {
+      "position": 10,
+      "song_id": "765as_ポジティブシンカー",
+      "performers": [
+        "765as_双海亜美"
+      ]
+    },
+    {
+      "position": 11,
+      "song_id": "765as_funny_logic",
+      "performers": "all"
+    },
+    {
+      "position": 12,
+      "song_id": "765as_ジェミー",
+      "performers": [
+        "765as_双海真美"
+      ]
+    },
+    {
+      "position": 13,
+      "song_id": "ml_微笑んだから気づいたんだ",
+      "performers": [
+        "765as_双海亜美"
+      ]
+    },
+    {
+      "position": 14,
+      "song_id": "765as_キミはメロディ",
+      "performers": [
+        "765as_双海真美"
+      ]
+    },
+    {
+      "position": 15,
+      "song_id": "765as_スタトスタ",
+      "performers": "all"
+    },
+    {
+      "position": 16,
+      "song_id": "765as_brave_star",
+      "performers": "all"
+    },
+    {
+      "position": 17,
+      "song_id": "765as_new_me_continued",
+      "performers": "all"
+    }
+  ]
+}

--- a/data/setlists/20260813_popn_toybox_yugata.json
+++ b/data/setlists/20260813_popn_toybox_yugata.json
@@ -1,0 +1,210 @@
+{
+  "title": "CINDERELLA GIRLS CONCEPT xR LIVE Pop'n ToyBox!! 夕方公演 (2026-08-13 Shibuya LOVEZ) セットリスト",
+  "show_id": "sh_cinderella_girls_concept_xr_live_pop_n_toybox_1",
+  "source": "https://aimasupay.hatenablog.com/entry/2026/08/13/182308",
+  "_sources": [
+    "https://aimasupay.hatenablog.com/entry/2026/08/13/182308",
+    "https://asobistage.asobistore.jp/event/cinderella_cg_ptb/information",
+    "https://idolmaster-official.jp/live_event/cg_ptb/",
+    "https://columbia.jp/idolmaster/imasnews/260717.html"
+  ],
+  "_note": "performers は歌唱アイドル。サポートメンバーは歌唱せずダンスのみ参加のため notes に記録",
+  "songs": [
+    {
+      "position": 1,
+      "song_id": "cg_poppin_para_pong",
+      "performers": [
+        "cg_赤城みりあ",
+        "cg_市原仁奈",
+        "cg_椎名法子"
+      ],
+      "notes": "新曲初披露 (会場オリジナルCD SACX-1144 表題曲)"
+    },
+    {
+      "position": 2,
+      "song_id": "cg_romantic_now",
+      "performers": [
+        "cg_赤城みりあ"
+      ]
+    },
+    {
+      "position": 3,
+      "song_id": "cg_ギョーてんしーわーるど",
+      "performers": [
+        "cg_市原仁奈",
+        "cg_浅利七海",
+        "cg_龍崎薫"
+      ],
+      "notes": "ダンス参加: 池袋晶葉"
+    },
+    {
+      "position": 4,
+      "song_id": "cg_にんぎょひめ練習中",
+      "performers": [
+        "cg_浅利七海"
+      ]
+    },
+    {
+      "position": 5,
+      "song_id": "cg_みんなのきもち",
+      "performers": [
+        "cg_市原仁奈"
+      ]
+    },
+    {
+      "position": 6,
+      "song_id": "cg_nocturne",
+      "performers": [
+        "cg_高垣楓",
+        "cg_川島瑞樹"
+      ]
+    },
+    {
+      "position": 7,
+      "song_id": "cg_弾丸サバイバー",
+      "performers": [
+        "cg_大和亜季"
+      ]
+    },
+    {
+      "position": 8,
+      "song_id": "cg_max_beat",
+      "performers": [
+        "cg_大和亜季",
+        "cg_高垣楓",
+        "cg_鷹富士茄子"
+      ],
+      "notes": "ダンス参加: 高橋礼子・財前時子"
+    },
+    {
+      "position": 9,
+      "song_id": "cg_熱情エナモラル",
+      "performers": [
+        "cg_佐藤心",
+        "cg_大和亜季"
+      ],
+      "notes": "ダンス参加: 東郷あい・篠原礼・黒川千秋"
+    },
+    {
+      "position": 10,
+      "song_id": "cg_レッドソール",
+      "performers": [
+        "cg_三船美優",
+        "cg_鷹富士茄子"
+      ],
+      "notes": "ダンス参加: 篠原礼・柊志乃"
+    },
+    {
+      "position": 11,
+      "song_id": "cg_lovedestiny",
+      "performers": [
+        "cg_佐城雪美"
+      ],
+      "notes": "ダンス参加: 黒川千秋"
+    },
+    {
+      "position": 12,
+      "song_id": "cg_とくとく_とく",
+      "performers": [
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 13,
+      "song_id": "cg_morgana",
+      "performers": [
+        "cg_浅利七海"
+      ],
+      "notes": "ダンス参加: 柊志乃"
+    },
+    {
+      "position": 14,
+      "song_id": "cg_プライスレス_ドーナッcyu",
+      "performers": [
+        "cg_椎名法子"
+      ],
+      "notes": "ダンス参加: 財前時子"
+    },
+    {
+      "position": 15,
+      "song_id": "cg_恋のhamburg",
+      "performers": [
+        "cg_龍崎薫"
+      ],
+      "notes": "ダンス参加: 東郷あい"
+    },
+    {
+      "position": 16,
+      "song_id": "cg_ひまわりマークをさがせ",
+      "performers": [
+        "cg_龍崎薫"
+      ]
+    },
+    {
+      "position": 17,
+      "song_id": "cg_悠久星涼",
+      "performers": [
+        "cg_龍崎薫",
+        "cg_椎名法子",
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 18,
+      "song_id": "cg_クレイジークレイジー",
+      "performers": [
+        "cg_佐藤心",
+        "cg_鷹富士茄子"
+      ]
+    },
+    {
+      "position": 19,
+      "song_id": "cg_初夢をあなたと",
+      "performers": [
+        "cg_鷹富士茄子"
+      ]
+    },
+    {
+      "position": 20,
+      "song_id": "cg_私色ギフト",
+      "performers": [
+        "cg_赤城みりあ"
+      ],
+      "notes": "ダンス参加: 高橋礼子・佐藤心・東郷あい"
+    },
+    {
+      "position": 21,
+      "song_id": "cg_dreaming_of_you",
+      "performers": [
+        "cg_川島瑞樹"
+      ]
+    },
+    {
+      "position": 22,
+      "song_id": "cg_がおちゅーさふぁりぱーく",
+      "performers": [
+        "cg_三船美優",
+        "cg_市原仁奈"
+      ],
+      "notes": "ダンス参加: 高橋礼子・赤城みりあ"
+    },
+    {
+      "position": 23,
+      "song_id": "cg_もしもカワイイが世界からなくなっても",
+      "performers": [
+        "cg_佐藤心"
+      ],
+      "notes": "ダンス参加: ほか出演アイドル多数"
+    },
+    {
+      "position": 24,
+      "song_id": "cg_cookie_dough",
+      "performers": [
+        "cg_三船美優",
+        "cg_高垣楓",
+        "cg_大和亜季"
+      ],
+      "notes": "新曲初披露 (会場オリジナルCD SACX-1145 表題曲)"
+    }
+  ]
+}

--- a/data/setlists/20260814_popn_toybox_hiru.json
+++ b/data/setlists/20260814_popn_toybox_hiru.json
@@ -1,0 +1,189 @@
+{
+  "title": "CINDERELLA GIRLS CONCEPT xR LIVE Pop'n ToyBox!! 昼公演 (2026-08-14 Shibuya LOVEZ) セットリスト",
+  "show_id": "sh_cinderella_girls_concept_xr_live_pop_n_toybox_2",
+  "source": "https://aimasupay.hatenablog.com/entry/2026/08/14/162302",
+  "_sources": [
+    "https://aimasupay.hatenablog.com/entry/2026/08/14/162302",
+    "https://idolmaster-official.jp/live_event/cg_ptb/",
+    "https://columbia.jp/idolmaster/imasnews/260717.html"
+  ],
+  "_note": "本編前に「ラジオ体操第一」を実施 (アイマス楽曲ではないため楽曲としては登録せず position 1 の notes に記録)",
+  "songs": [
+    {
+      "position": 1,
+      "song_id": "cg_みんなのきもち",
+      "performers": [
+        "cg_市原仁奈"
+      ],
+      "notes": "開幕に「ラジオ体操第一」(号令: 日野茜・声のみ) を実施"
+    },
+    {
+      "position": 2,
+      "song_id": "cg_ギョーてんしーわーるど",
+      "performers": [
+        "cg_市原仁奈",
+        "cg_浅利七海",
+        "cg_龍崎薫"
+      ],
+      "notes": "ダンス参加: 池袋晶葉"
+    },
+    {
+      "position": 3,
+      "song_id": "cg_プライスレス_ドーナッcyu",
+      "performers": [
+        "cg_椎名法子"
+      ]
+    },
+    {
+      "position": 4,
+      "song_id": "cg_にんぎょひめ練習中",
+      "performers": [
+        "cg_浅利七海"
+      ]
+    },
+    {
+      "position": 5,
+      "song_id": "cg_motto",
+      "performers": [
+        "cg_椎名法子",
+        "cg_浅利七海"
+      ]
+    },
+    {
+      "position": 6,
+      "song_id": "cg_romantic_now",
+      "performers": [
+        "cg_赤城みりあ"
+      ]
+    },
+    {
+      "position": 7,
+      "song_id": "cg_kawaii_make_my_day",
+      "performers": [
+        "cg_椎名法子"
+      ]
+    },
+    {
+      "position": 8,
+      "song_id": "cg_おねえちゃんデスコ",
+      "performers": [
+        "cg_市原仁奈"
+      ],
+      "notes": "ライブ初披露"
+    },
+    {
+      "position": 9,
+      "song_id": "cg_私色ギフト",
+      "performers": [
+        "cg_赤城みりあ"
+      ],
+      "notes": "ダンス参加: 高橋礼子・佐藤心・東郷あい"
+    },
+    {
+      "position": 10,
+      "song_id": "cg_がおちゅーさふぁりぱーく",
+      "performers": [
+        "cg_三船美優",
+        "cg_市原仁奈"
+      ],
+      "notes": "ダンス参加: 高橋礼子・赤城みりあ"
+    },
+    {
+      "position": 11,
+      "song_id": "cg_ささのはにうたかたに",
+      "performers": [
+        "cg_鷹富士茄子",
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 12,
+      "song_id": "cg_恋のhamburg",
+      "performers": [
+        "cg_龍崎薫"
+      ],
+      "notes": "ダンス参加: 東郷あい"
+    },
+    {
+      "position": 13,
+      "song_id": "cg_ひまわりマークをさがせ",
+      "performers": [
+        "cg_龍崎薫"
+      ]
+    },
+    {
+      "position": 14,
+      "song_id": "cg_lovedestiny",
+      "performers": [
+        "cg_佐城雪美"
+      ],
+      "notes": "ダンス参加: 黒川千秋"
+    },
+    {
+      "position": 15,
+      "song_id": "cg_君のステージ衣装本当は",
+      "performers": [
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 16,
+      "song_id": "cg_morgana",
+      "performers": [
+        "cg_浅利七海"
+      ],
+      "notes": "ダンス参加: 柊志乃"
+    },
+    {
+      "position": 17,
+      "song_id": "cg_廻談詣り",
+      "performers": [
+        "cg_浅利七海",
+        "cg_佐城雪美"
+      ],
+      "notes": "ダンス参加: 高橋礼子・柊志乃・東郷あい・財前時子・黒川千秋・篠原礼"
+    },
+    {
+      "position": 18,
+      "song_id": "cg_悠久星涼",
+      "performers": [
+        "cg_龍崎薫",
+        "cg_椎名法子",
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 19,
+      "song_id": "cg_とくとく_とく",
+      "performers": [
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 20,
+      "song_id": "cg_わたぐも",
+      "performers": [
+        "cg_赤城みりあ"
+      ]
+    },
+    {
+      "position": 21,
+      "song_id": "cg_よりみちリトルスター",
+      "performers": [
+        "cg_赤城みりあ",
+        "cg_龍崎薫",
+        "cg_市原仁奈",
+        "cg_佐城雪美"
+      ]
+    },
+    {
+      "position": 22,
+      "song_id": "cg_poppin_para_pong",
+      "performers": [
+        "cg_赤城みりあ",
+        "cg_市原仁奈",
+        "cg_椎名法子"
+      ]
+    }
+  ]
+}

--- a/data/setlists/20260814_popn_toybox_yoru.json
+++ b/data/setlists/20260814_popn_toybox_yoru.json
@@ -1,0 +1,214 @@
+{
+  "title": "CINDERELLA GIRLS CONCEPT xR LIVE Pop'n ToyBox!! 夜公演 (2026-08-14 Shibuya LOVEZ) セットリスト",
+  "show_id": "sh_cinderella_girls_concept_xr_live_pop_n_toybox_3",
+  "source": "https://aimasupay.hatenablog.com/entry/2026/08/14/213404",
+  "_sources": [
+    "https://aimasupay.hatenablog.com/entry/2026/08/14/213404",
+    "https://idolmaster-official.jp/live_event/cg_ptb/",
+    "https://columbia.jp/idolmaster/imasnews/260717.html"
+  ],
+  "_note": "performers は歌唱アイドル。サポートメンバーは歌唱せずダンスのみ参加のため notes に記録",
+  "songs": [
+    {
+      "position": 1,
+      "song_id": "cg_ジュビリー",
+      "performers": [
+        "cg_高垣楓"
+      ],
+      "section": "～COOL～",
+      "notes": "ダンス参加: 東郷あい・黒川千秋"
+    },
+    {
+      "position": 2,
+      "song_id": "cg_max_beat",
+      "performers": [
+        "cg_大和亜季",
+        "cg_高垣楓",
+        "cg_鷹富士茄子"
+      ],
+      "section": "～COOL～",
+      "notes": "ダンス参加: 高橋礼子・財前時子"
+    },
+    {
+      "position": 3,
+      "song_id": "cg_レッドソール",
+      "performers": [
+        "cg_三船美優",
+        "cg_鷹富士茄子"
+      ],
+      "section": "～COOL～",
+      "notes": "ダンス参加: 篠原礼・柊志乃"
+    },
+    {
+      "position": 4,
+      "song_id": "cg_弾丸サバイバー",
+      "performers": [
+        "cg_大和亜季"
+      ],
+      "section": "～COOL～"
+    },
+    {
+      "position": 5,
+      "song_id": "cg_秘密のトワレ",
+      "performers": [
+        "cg_川島瑞樹",
+        "cg_三船美優"
+      ],
+      "section": "～COOL～"
+    },
+    {
+      "position": 6,
+      "song_id": "cg_nocturne",
+      "performers": [
+        "cg_高垣楓",
+        "cg_川島瑞樹"
+      ],
+      "section": "～COOL～"
+    },
+    {
+      "position": 7,
+      "song_id": "cg_angel_breeze",
+      "performers": [
+        "cg_川島瑞樹"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 8,
+      "song_id": "cg_初夢をあなたと",
+      "performers": [
+        "cg_鷹富士茄子"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 9,
+      "song_id": "cg_take_metake_you",
+      "performers": [
+        "cg_三船美優",
+        "cg_高垣楓",
+        "cg_佐藤心"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 10,
+      "song_id": "cg_オルゴールの小箱",
+      "performers": [
+        "cg_川島瑞樹",
+        "cg_三船美優"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 11,
+      "song_id": "cg_流星浪漫",
+      "performers": [
+        "cg_鷹富士茄子"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 12,
+      "song_id": "cg_つぼみ",
+      "performers": [
+        "cg_高垣楓"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 13,
+      "song_id": "cg_dreaming_of_you",
+      "performers": [
+        "cg_川島瑞樹"
+      ],
+      "section": "～Easy-going～"
+    },
+    {
+      "position": 14,
+      "song_id": "cg_ダンスダンスダンス_-ミフメイ_remix-",
+      "performers": [
+        "cg_高橋礼子",
+        "cg_東郷あい",
+        "cg_財前時子",
+        "cg_黒川千秋",
+        "cg_柊志乃",
+        "cg_篠原礼"
+      ],
+      "section": "～Midnight Dance Performance～",
+      "notes": "歌唱なし・サポートアイドルによるダンスパフォーマンスのみ"
+    },
+    {
+      "position": 15,
+      "song_id": "cg_熱情エナモラル",
+      "performers": [
+        "cg_佐藤心",
+        "cg_大和亜季"
+      ],
+      "section": "～Sexy～",
+      "notes": "ダンス参加: 東郷あい・篠原礼・黒川千秋"
+    },
+    {
+      "position": 16,
+      "song_id": "cg_last_kiss",
+      "performers": [
+        "cg_三船美優"
+      ],
+      "section": "～Sexy～"
+    },
+    {
+      "position": 17,
+      "song_id": "cg_next_chapter",
+      "performers": [
+        "cg_佐藤心"
+      ],
+      "section": "～Sexy～",
+      "notes": "ダンス参加: 黒川千秋・柊志乃・高橋礼子・財前時子"
+    },
+    {
+      "position": 18,
+      "song_id": "cg_クレイジークレイジー",
+      "performers": [
+        "cg_佐藤心",
+        "cg_鷹富士茄子"
+      ],
+      "section": "～Sexy～"
+    },
+    {
+      "position": 19,
+      "song_id": "cg_little_more",
+      "performers": [
+        "cg_三船美優"
+      ],
+      "section": "～Sexy～"
+    },
+    {
+      "position": 20,
+      "song_id": "cg_cookie_dough",
+      "performers": [
+        "cg_三船美優",
+        "cg_高垣楓",
+        "cg_大和亜季"
+      ],
+      "section": "～Sexy～"
+    },
+    {
+      "position": 21,
+      "song_id": "cg_サマーサイダー",
+      "performers": [
+        "cg_高垣楓",
+        "cg_川島瑞樹"
+      ],
+      "section": "～ENCORE～"
+    },
+    {
+      "position": 22,
+      "song_id": "cg_もしもカワイイが世界からなくなっても",
+      "performers": [
+        "cg_佐藤心"
+      ],
+      "section": "～ENCORE～",
+      "notes": "ダンス参加: 鷹富士茄子・大和亜季・篠原礼・黒川千秋・東郷あい・財前時子・高橋礼子・柊志乃・川島瑞樹・高垣楓・三船美優"
+    }
+  ]
+}

--- a/data/songs/20260814_live_new_songs.json
+++ b/data/songs/20260814_live_new_songs.json
@@ -1,0 +1,96 @@
+{
+  "title": "2026年8月ライブ会場オリジナルCD等の新曲追加",
+  "_help": "dual twin live tour / Pop'n ToyBox!! の会場オリジナルCD新曲と、夜公演で使用されたリミックス",
+  "source": "https://columbia.jp/idolmaster/imasnews/260807.html",
+  "songs": [
+    {
+      "id": "765as_北極星をズラしちゃえ",
+      "title": "北極星をズラしちゃえ！",
+      "brand_id": "765as",
+      "song_type": "unit",
+      "release_date": "2026-08-06",
+      "lyricist": "星部ショウ",
+      "composer": "星部ショウ",
+      "arranger": "明石裕太",
+      "cd_series": "765PRO_ALLSTARSライブ会場限定CD_2#dual_twin_live_futagoboshi",
+      "cd_title": "THE IDOLM@STER dual twin live tour 双海 亜美・双海 真美 twin live “ ふたごぼしのつばさ ”（会場オリジナルCD）",
+      "original_singers": [
+        "765as_双海亜美",
+        "765as_双海真美"
+      ],
+      "source": "https://columbia.jp/idolmaster/imasnews/260807.html",
+      "note": "会場オリジナルCD SACX-1140 表題曲。2026-08-06 ワクワクフタリボシ公演 (Zepp Namba) で初披露"
+    },
+    {
+      "id": "765as_binary_star",
+      "title": "Binary Star",
+      "brand_id": "765as",
+      "song_type": "unit",
+      "release_date": "2026-08-06",
+      "lyricist": "パソコン音楽クラブ",
+      "composer": "パソコン音楽クラブ",
+      "arranger": "パソコン音楽クラブ",
+      "cd_series": "765PRO_ALLSTARSライブ会場限定CD_2#dual_twin_live_tsumimatsu",
+      "cd_title": "THE IDOLM@STER dual twin live tour 三浦 あずさ・秋月 律子 twin live “ つみまつよるまち ”（会場オリジナルCD）",
+      "original_singers": [
+        "765as_三浦あずさ",
+        "765as_秋月律子"
+      ],
+      "source": "https://columbia.jp/idolmaster/imasnews/260807.html",
+      "note": "会場オリジナルCD SACX-1139 表題曲。2026-08-07 OSAKA SILENTCITY LOVE 公演 (Zepp Namba) で初披露"
+    },
+    {
+      "id": "cg_poppin_para_pong",
+      "title": "Poppin' para Pong!",
+      "brand_id": "cg",
+      "song_type": "unit",
+      "release_date": "2026-08-13",
+      "lyricist": "烏屋茶房",
+      "composer": "橘亮祐",
+      "arranger": "橘亮祐",
+      "cd_series": "CINDERELLA_GIRLSのライブ会場限定CD#popn_toybox",
+      "cd_title": "THE IDOLM@STER CINDERELLA GIRLS CONCEPT xR LIVE Pop'n ToyBox!! Poppin' para Pong!",
+      "original_singers": [
+        "cg_赤城みりあ",
+        "cg_市原仁奈",
+        "cg_椎名法子"
+      ],
+      "source": "https://columbia.jp/idolmaster/imasnews/260717.html",
+      "note": "会場オリジナルCD SACX-1144 表題曲。2026-08-13 夕方公演 (Shibuya LOVEZ) で初披露"
+    },
+    {
+      "id": "cg_cookie_dough",
+      "title": "Cookie Dough",
+      "brand_id": "cg",
+      "song_type": "unit",
+      "release_date": "2026-08-13",
+      "lyricist": "八城雄太",
+      "composer": "設楽哲也",
+      "arranger": "設楽哲也",
+      "cd_series": "CINDERELLA_GIRLSのライブ会場限定CD#popn_toybox",
+      "cd_title": "THE IDOLM@STER CINDERELLA GIRLS CONCEPT xR LIVE Pop'n ToyBox!! Cookie Dough",
+      "original_singers": [
+        "cg_高垣楓",
+        "cg_三船美優",
+        "cg_大和亜季"
+      ],
+      "source": "https://columbia.jp/idolmaster/imasnews/260717.html",
+      "note": "会場オリジナルCD SACX-1145 表題曲。2026-08-13 夕方公演 (Shibuya LOVEZ) で初披露"
+    },
+    {
+      "id": "cg_ダンスダンスダンス_-ミフメイ_remix-",
+      "title": "ダンス・ダンス・ダンス -ミフメイ Remix-",
+      "brand_id": "cg",
+      "song_type": "all",
+      "release_date": "2025-11-29",
+      "lyricist": "MC TC",
+      "composer": "TAKU INOUE",
+      "arranger": "ミフメイ",
+      "parent_song_id": "765as_ダンスダンスダンス",
+      "cd_series": "CINDERELLA_GIRLSのライブ会場限定CD#to_dnce_to_fes",
+      "cd_title": "THE IDOLM@STER CINDERELLA GIRLS TO D@NCE TO FES!",
+      "source": "https://columbia.jp/idolmaster/imasnews/251219.html",
+      "note": "SACX-1127〜8 DISC1 Tr.01 (CINDERELLA GIRLS fes. Once Upon a St@rs 会場オリジナルCD)。歌唱アイドルはCD・公式に記載が無いため original_singers は未設定 (原曲は parent_song_id で参照)"
+    }
+  ]
+}

--- a/docs/DATA_PIPELINE.md
+++ b/docs/DATA_PIPELINE.md
@@ -47,6 +47,23 @@ CLOUDKIT_KEY_ID=$KID python3 tools/apply_data.py --apply --push --production  # 
 スキーマを変えた時 (列追加等) は、ローカル master.sqlite から `sqlite3 ... .dump > db/master.sql` で
 dump を作り直してコミットする (cron はデータのみ更新し、スキーマは db/master.sql 由来のため)。
 
+### `meta.data_version` (これが落ちるとユーザーに届かない)
+
+アプリの reseed は **bundle 側 `data_version` > 端末側** のときだけ走る
+(`AppDatabase.reseedMasterTablesIfNeeded`)。つまり:
+
+- **`meta` が消えた dump を配ると reseed が二度と発火しない。** bundle 側が `0` と読まれ、
+  既存ユーザーは無言で旧データのまま固定される。FK ゲートでは検知できない種類の事故。
+  `meta` は CloudKit 側に実体が無いので、`export_cloudkit.py` の `PRESERVED_TABLES` で
+  refresh 対象から外して既存 dump の値を引き継ぐ。
+- **データを入れても `data_version` を上げなければ既存ユーザーには届かない。**
+  cron は「マスタに実差分があった回だけ」+1 する (差分判定は `data_version` 行を除いて比較。
+  バンプ自体が差分になる循環を避けるため)。手で `--apply --push` した分も、翌日の cron が
+  差分を拾って上げるので通常は追加操作は不要。
+
+`tools/build_db.sh` は FK 整合性に加えて `data_version` の存在も検証し、欠けていれば
+master.sqlite の生成を失敗させる。
+
 ## コミュニティデータ (D1) のバックアップ / スナップショット
 
 マスタ (CloudKit) は日次 cron で `db/master.sql` に落ちるので失っても戻せる。

--- a/tools/apply_data.py
+++ b/tools/apply_data.py
@@ -77,14 +77,23 @@ def load(kind):
     return out
 
 
-def resolve_song(conn, brand_id, song_id, title):
-    """song_id 優先。無ければ brand 内でタイトル完全一致を試みる。"""
+def resolve_song(conn, brand_id, song_id, title, pending=()):
+    """song_id 優先。無ければ brand 内でタイトル完全一致を試みる。
+
+    pending は同じバッチで data/songs/ に追加される新曲。新曲を登録して同じ PR で
+    その初披露のセトリも入れる、という普通の流れを --check で弾かないために見る
+    (apply_all は songs → setlists の順に入れるので、反映時点では実在する)。
+    """
     if song_id:
+        if any(p.get("id") == song_id for p in pending):
+            return song_id
         return song_id if exists(conn, "songs", song_id) else None
-    rows = conn.execute(
+    hits = {p["id"] for p in pending
+            if p.get("id") and p.get("brand_id") == brand_id and p.get("title") == title}
+    hits |= {r[0] for r in conn.execute(
         "SELECT id FROM songs WHERE brand_id = ? AND title = ?", (brand_id, title)
-    ).fetchall()
-    return rows[0][0] if len(rows) == 1 else None
+    )}
+    return next(iter(hits)) if len(hits) == 1 else None
 
 
 # ---- 検証 -----------------------------------------------------------------
@@ -116,6 +125,9 @@ def validate(conn):
             if s.get("unit_id") and not exists(conn, "units", s["unit_id"]):
                 problems.append(f"{tag}: unit_id '{s['unit_id']}' が存在しない")
 
+    # 同じバッチで追加される新曲。セトリ側はこれも「存在する」として解決する。
+    new_songs = [s for _, d in load("songs") for s in d.get("songs", [])]
+
     for path, data in load("setlists"):
         need_source(path, data)
         show_id = data.get("show_id")
@@ -129,7 +141,7 @@ def validate(conn):
         brand_id = brand[0] if brand else None
         for i, sg in enumerate(data.get("songs", [])):
             tag = f"setlists/{path.name}[pos {sg.get('position')}]"
-            sid = resolve_song(conn, brand_id, sg.get("song_id"), sg.get("title"))
+            sid = resolve_song(conn, brand_id, sg.get("song_id"), sg.get("title"), new_songs)
             if not sid:
                 problems.append(f"{tag}: 曲を特定できない (song_id か brand内一意なtitleが必要): {sg.get('title')}")
             perf = sg.get("performers")

--- a/tools/build_db.sh
+++ b/tools/build_db.sh
@@ -18,4 +18,19 @@ python3 "$ROOT/tools/check_fk_integrity.py" "$DB" || {
   rm -f "$DB"
   exit 1
 }
+
+# data_version ゲート (必須): reseed は bundle 側 data_version > 端末側 のときだけ走る。
+# meta が欠けた master.sqlite を同梱すると bundle=0 と読まれ、既存ユーザーでは reseed が
+# 二度と発火せず、無言で旧データのまま固定される (FK ゲートでは検知できない)。
+python3 - "$DB" <<'PY' || { rm -f "$DB"; exit 1; }
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+row = conn.execute("SELECT value FROM meta WHERE key = 'data_version'").fetchone()
+version = int(row[0]) if row and str(row[0]).isdigit() else 0
+if version <= 0:
+    print("✗ meta.data_version が無い/不正。master.sqlite の同梱を中止 "
+          "(このまま配ると既存ユーザーの reseed が止まる)。", file=sys.stderr)
+    sys.exit(1)
+print(f"✅ meta.data_version: {version}")
+PY
 echo "✓ $DB を db/master.sql から再生成"

--- a/tools/export_cloudkit.py
+++ b/tools/export_cloudkit.py
@@ -11,7 +11,12 @@ seed_cloudkit.py の逆向き。CloudKit の全マスタレコードを query �
         --key-file tools/eckey.pem
 
 スキーマと非同期テーブル(meta / song_units 等)は既存の db/master.sql から引き継ぎ、
-CloudKit に存在するテーブルだけ中身を入れ替える。
+CloudKit に存在するテーブルだけ中身を入れ替える (PRESERVED_TABLES 参照)。
+
+マスタに実差分があった回だけ meta.data_version を +1 する。ここが上がらないと
+アプリ側の reseed (bundle > 端末) が発火せず、CloudKit に入ったデータが既存
+ユーザーに届かない。差分判定は data_version 行を除いて比較する (バンプ自体が
+差分になる循環を避けるため)。
 """
 from __future__ import annotations
 
@@ -27,6 +32,13 @@ import seed_cloudkit as sk  # 同ディレクトリ。署名・query・テーブ
 ROOT = Path(__file__).resolve().parent.parent
 DUMP_PATH = ROOT / "db" / "master.sql"
 DB_PATH = ROOT / "ImasLiveDB" / "Resources" / "master.sqlite"
+
+# CloudKit に RecordType はあるが、master としては既存 dump 側が正のテーブル。
+# meta は RECORD_TYPE_MAP に載っているので、外さないと refresh_table の
+# DELETE FROM meta で消える。CloudKit 側に MetaData レコードは無いため
+# 空のまま dump され、bundle 側 data_version が 0 になって
+# AppDatabase.reseedMasterTablesIfNeeded が二度と走らなくなる。
+PRESERVED_TABLES = {"meta"}
 
 
 def camel_to_snake(name: str) -> str:
@@ -132,11 +144,56 @@ def build_conn_from_dump() -> sqlite3.Connection:
     return conn
 
 
-def write_dump(conn):
-    DUMP_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(DUMP_PATH, "w", encoding="utf-8") as f:
-        for line in conn.iterdump():
-            f.write(line + "\n")
+def dump_text(conn) -> str:
+    return "".join(line + "\n" for line in conn.iterdump())
+
+
+_DATA_VERSION_RE = re.compile(
+    r"""^INSERT INTO ["']?meta["']?\s+VALUES\('data_version'.*$\n?""", re.M
+)
+
+
+def data_only(dump: str) -> str:
+    """data_version 行を除いた dump。バンプ自体が差分を生む循環を避けて比較するため。"""
+    return _DATA_VERSION_RE.sub("", dump)
+
+
+def comparable(sql_text: str) -> str:
+    """dump テキストを比較可能な正規形にする。
+
+    db/master.sql には 2 系統の形式が混在する。オーナーが手で作り直した回は
+    sqlite3 CLI の .dump (テーブル名クォート無し・sqlite_master 順)、cron の回は
+    iterdump (クォート有り・別順) で、生テキスト比較だと常に「差分あり」になる。
+    一度 DB に読み込んで同じ iterdump に通し、書式と行順を揃えてから比べる。
+    """
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(sql_text)
+        return data_only(dump_text(conn))
+    finally:
+        conn.close()
+
+
+def read_data_version(conn) -> int:
+    row = conn.execute("SELECT value FROM meta WHERE key = 'data_version'").fetchone()
+    return int(row[0]) if row and str(row[0]).isdigit() else 0
+
+
+def bump_data_version(conn) -> int:
+    """data_version を +1 する。
+
+    アプリの reseed は bundle 側 data_version > 端末側 のときだけ走る
+    (AppDatabase.reseedMasterTablesIfNeeded)。ここを上げないと、CloudKit に入って
+    db/master.sql まで来たデータが既存ユーザーに永久に届かない。
+    """
+    new = read_data_version(conn) + 1
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES ('data_version', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (str(new),),
+    )
+    conn.commit()
+    return new
 
 
 def main():
@@ -154,17 +211,38 @@ def main():
         sys.exit(1)
     sk.init_session(args.key_id, Path(args.key_file))
 
+    before = DUMP_PATH.read_text(encoding="utf-8") if DUMP_PATH.exists() else ""
+
     conn = build_conn_from_dump()
     conn.execute("PRAGMA foreign_keys = OFF")
     print(f"CloudKit ({env}) から master を取得:")
     total = 0
     for table in sk.TABLE_ORDER:
+        if table in PRESERVED_TABLES:
+            continue
         if table in sk.RECORD_TYPE_MAP and sk.get_column_info(conn, table):
             total += refresh_table(conn, table)
     conn.commit()
-    write_dump(conn)
+
+    after = dump_text(conn)
+    if data_only(after) != comparable(before):
+        new_version = bump_data_version(conn)
+        after = dump_text(conn)
+        print(f"\nマスタに差分あり → data_version {new_version - 1} → {new_version}")
+    else:
+        print(f"\nマスタに差分なし → data_version {read_data_version(conn)} 据え置き")
+
+    # data_version が落ちた dump を出すと、既存ユーザーの reseed が bundle=0 で
+    # 止まり無言で旧データのまま固定される。書き出す前にここで落とす。
+    if read_data_version(conn) <= 0:
+        print("✗ meta.data_version が無い/不正。db/master.sql を書き換えず中止。", file=sys.stderr)
+        conn.close()
+        sys.exit(1)
+
+    DUMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DUMP_PATH.write_text(after, encoding="utf-8")
     conn.close()
-    print(f"\n✓ {total} 行を db/master.sql に書き出し")
+    print(f"✓ {total} 行を db/master.sql に書き出し")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
2026年8月の公演のセットリストと新曲の投入に加えて、調査中に見つかった日次 cron の不具合を直します。

> [!IMPORTANT]
> **このPRを `bot/data-refresh` より先にマージしてください。** 現在の `bot/data-refresh` は `meta` が空で、先に取り込むと既存ユーザーのマスタ更新が無言で止まります (下記)。

---

## 1. cron エクスポートで `meta` が消えて reseed が止まる

日次 cron が吐く `db/master.sql` から `meta` が丸ごと消えていました。

```
INSERT INTO meta  →  develop: 3行 / bot/data-refresh: 0行
```

`meta` が `seed_cloudkit.py:103` の `RECORD_TYPE_MAP` に `"MetaData"` として載っているため `refresh_table` の `DELETE FROM meta` で消え、CloudKit 側に MetaData レコードが無いので空のまま dump されていました。`export_cloudkit.py` の docstring は「非同期テーブル(meta / song_units 等)は既存の db/master.sql から引き継ぎ」と書いてあり、意図と実装が食い違っていました。

これを取り込むと `AppDatabase.swift:168-175` で bundle 側が `0` と読まれ、

```swift
guard bundleVersion > localVersion else { return }   // 0 > 65 → reseed しない
```

既存ユーザーは無言で旧データのまま固定されます。FKゲートでは検知できない種類の事故です。→ `meta` を `PRESERVED_TABLES` で refresh 対象から外しました。

## 2. `data_version` が上がらないとデータが届かない

これまで `data_version` はオーナーがデータコミット時に手で上げていました (`61→63→64→65`)。cron 側は上げないので、cron 経由で入ったデータは既存ユーザーに届きません。**マスタに実差分があった回だけ +1** するようにしました。

差分判定は dump の生テキストでは行えません。`db/master.sql` には sqlite3 CLI の `.dump` (テーブル名クォート無し・sqlite_master 順) と `iterdump` (クォート有り・別順) が混在しており、生比較だと常に差分ありになって毎回バンプします。一度DBに読み込んで同じ `iterdump` に通し、書式と行順を揃えてから `data_version` 行を除いて比較します。

`build_db.sh` にも `data_version` ゲートを追加し、欠けた master.sqlite が同梱されるのをFKゲートと同様に止めます。

### 検証

CloudKitに繋がずロジック単体で確認済み:

| ケース | 結果 |
|---|---|
| CLI形式ファイル vs 同内容のiterdump | 差分なし（毎回バンプしない） |
| 1行追加 | 差分あり → 65→66 |
| `data_version` のみ違う | 差分なし（循環しない） |
| バンプ結果を書き戻した次回 | 差分なし（収束する） |
| 現 `bot/data-refresh` (meta空) | ゲート発動 exit=1 |

### 未マージデータについて

`origin/develop` と `origin/bot/data-refresh` を全テーブル突き合わせた結果、**git にしか無いレコードは0件** (CloudKitのみ: events 8 / shows 7 / songs 8 / show_cast 31 / song_artists 21 / unit_members 3)。cron は毎回CloudKitから全件再エクスポートして force push するので、PRを溜めてもデータは失われません。

なお、このPRのマージ後の初回 cron は形式が `iterdump` に揃うため、一度だけ大きな書式差分のコミットが出ます（`data_version` は据え置き）。

---

## 3. セトリ 6公演・118曲

| show | 公演 | 曲数 |
|---|---|---|
| `..._dual_twin_..._1` | 8/6 ふたごぼしのつばさ [ワクワクフタリボシ] (Zepp Namba) | 17 |
| `..._dual_twin_..._2` | 8/7 つみまつよるまち [OSAKA SILENTCITY LOVE] (Zepp Namba) | 16 |
| `..._dual_twin_..._3` | 8/13 ふたごぼしのつばさ [ソワソワフタリボシ] (Zepp Nagoya) | 17 |
| `..._pop_n_toybox_1` | 8/13 Pop'n ToyBox!! 夕方公演 (Shibuya LOVEZ) | 24 |
| `..._pop_n_toybox_2` | 8/14 Pop'n ToyBox!! 昼公演 | 22 |
| `..._pop_n_toybox_3` | 8/14 Pop'n ToyBox!! 夜公演 | 22 |

- 曲はすべて `song_id` 直指定です。セトリに他ブランド曲 (`ml_嘆きのfraction` / `961_kiss` / `ml_discord_area` / `ml_i_do` など) が多く、`resolve_song` のタイトル解決は公演ブランド内に限定されるため title 依存だと解決できません。
- 夜公演は公式の区切り (`～COOL～` / `～Easy-going～` / `～Midnight Dance Performance～` / `～Sexy～` / `～ENCORE～`) を `section` に入れています。

## 4. 新曲 5曲

| id | 曲 | 歌 | 品番 |
|---|---|---|---|
| `765as_北極星をズラしちゃえ` | 北極星をズラしちゃえ！ | 双海亜美・双海真美 | SACX-1140 |
| `765as_binary_star` | Binary Star | 三浦あずさ・秋月律子 | SACX-1139 |
| `cg_poppin_para_pong` | Poppin' para Pong! | 赤城みりあ・市原仁奈・椎名法子 | SACX-1144 |
| `cg_cookie_dough` | Cookie Dough | 高垣楓・三船美優・大和亜季 | SACX-1145 |

加えて 8/14 夜公演 M14 の `ダンス・ダンス・ダンス -ミフメイ Remix-` が未登録だったため、TO D@NCE TO FES! (SACX-1127〜8, 2025-11-29) 収録曲として追加しています。

## 5. 未登録公演の追加

MIKI HOSHII SOLO SHOWCASE「THE FUTURE SPOTLIGHT」in KOREA (8/9 Gabin Art Hall, ソウル) が抜けていたので公式告知から追加しました。セトリのソースは見つかっていないため公演のみです。

## 6. `apply_data.py --check` の修正

`--check` が、同じバッチで追加する新曲を参照するセトリを「曲を特定できない」として弾いていました。新曲を登録して同じ PR でその初披露のセトリも入れるのは普通の流れで (`35cd1dc` のエクストリーム・オーバードライブと同じ形)、`apply_all` 自体は songs → setlists の順に入れるため反映はできます。`validate()` は `--apply` の前にも必ず走って `sys.exit(1)` するため、この修正なしでは今回のデータは反映自体ができません。

---

## レビューしてほしい点

- **Pop'n ToyBox!! のサポートメンバー**は公式案内どおり歌唱せずダンスのみのため、`performers` に入れず `notes` に「ダンス参加: 〜」として残しています。夜公演 M14 だけは歌唱者が居ないので、ダンサーを `performers` に入れて notes で明示しました。
- **昼公演冒頭の「ラジオ体操第一」** (号令: 日野茜・声のみ) はアイマス楽曲ではないため曲登録せず、position 1 の `notes` に事実だけ残しています。
- **`ダンス・ダンス・ダンス -ミフメイ Remix-`** は歌唱アイドルがCD・公式のどこにも記載が無いため `original_singers` を空にしました (原曲は `parent_song_id` で参照)。`brand_id` はCG会場CD収録を理由に `cg` にしていますが、原曲が `765as_ダンスダンスダンス` なので判断が割れるかもしれません。

## 埋まらなかったもの

- 8/14 つみまつよるまち [NAGOYA MISTY NIGHT] — 作成時点で未実施
- KIMCHIKURA Fes '26 (8/8) — 出演者は確認できたがセトリを公開しているソースが見つからず
- SideM PASSIONABLE READING SHOW (3/14-15) / 電音部DJ生配信 (3/3) / MIKI HOSHII SOLO SHOWCASE (5/15) は今回の対象外

`tools/apply_data.py --check` は全件妥当、DBコピーへの `--apply` 試行 + FK整合性チェックも0件違反です。出典URLは各JSONの `source` / `_sources` に入れてあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJZwzDju6KMmMpcJnC44nm