### PR TITLE
fix(lyrics): 歌詞本文の二重取り込みを validate で警告する (劇星☆戦隊ドラスターズ)

### DIFF
--- a/tools/lyrics/lyrics_json.py
+++ b/tools/lyrics/lyrics_json.py
@@ -73,6 +73,10 @@ INTERLUDE_BLANKS = 2
 BR_RE = re.compile(r"<\s*br\s*/?\s*>", re.IGNORECASE)
 # 素の HTML タグが残っていたら検出して警告する (取りこぼしの発見用)
 TAG_RE = re.compile(r"<[^>]{1,40}>")
+# 本文の二重化判定 (is_doubled_body)。全角スペースも除いて比べる。
+WHITESPACE_RE = re.compile(r"[\s\u3000]")
+# これより短い本文は「サビを 2 回歌う」だけでも半分ずつ一致しうるので判定しない。
+MIN_DOUBLED_BODY_CHARS = 200
 
 
 def default_source():
@@ -216,8 +220,24 @@ def validate_doc(doc, path):
     texts = [ln.get("text", "") for ln in lines if isinstance(ln, dict) and ln.get("kind") == "lyric"]
     if len(texts) > 3 and len(set(texts)) == 1:
         warnings.append("歌詞行が全て同一。貼り付け事故の疑い")
+    if is_doubled_body(texts):
+        warnings.append("本文の後半が前半の丸ごと繰り返し。取り込み元に歌詞が2回載っていた疑い")
 
     return errors, warnings
+
+
+def is_doubled_body(texts):
+    """歌詞本文が「同じ歌詞 2 回分」になっていないか。
+
+    歌ネットのページに歌詞が 2 回 (2 回目は文節ごとに分割) 載っていて、それを
+    そのまま取り込んで 200 行になった事故があった (sidem_劇星戦隊ドラスターズ,
+    2026-09-06)。行の切り方が違っても本文は同じなので、空白を除いた全文で見る。
+    """
+    body = WHITESPACE_RE.sub("", "".join(texts))
+    if len(body) < MIN_DOUBLED_BODY_CHARS or len(body) % 2:
+        return False
+    half = len(body) // 2
+    return body[:half] == body[half:]
 
 
 def cmd_init(args):

--- a/tools/lyrics/test/test_lyrics_json.py
+++ b/tools/lyrics/test/test_lyrics_json.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""lyrics_json.py の検証ロジックのユニットテスト。
+
+    python3 -m unittest discover -s tools/lyrics/test -p 'test_*.py'
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import lyrics_json as L  # noqa: E402
+
+
+def doc(texts):
+    return {"song_id": "x", "source": "test",
+            "lines": [{"kind": "lyric", "text": t} for t in texts]}
+
+
+# 判定の下限 (MIN_DOUBLED_BODY_CHARS) を確実に超える長さの本文。
+VERSE = ["高らかに空を飛んで　叡智の海渡って%d" % i for i in range(12)]
+
+
+class DoubledBodyTest(unittest.TestCase):
+    def test_same_body_twice_is_flagged(self):
+        self.assertTrue(L.is_doubled_body(VERSE + VERSE))
+
+    def test_second_copy_split_differently_is_flagged(self):
+        # 2 回目が文節ごとに分割されていても本文は同じ
+        split = [piece for t in VERSE for piece in t.split("　")]
+        self.assertTrue(L.is_doubled_body(VERSE + split))
+
+    def test_normal_body_is_not_flagged(self):
+        self.assertFalse(L.is_doubled_body(VERSE))
+
+    def test_short_body_is_ignored(self):
+        self.assertFalse(L.is_doubled_body(["ラララ"] * 4))
+
+    def test_validate_doc_warns(self):
+        errors, warnings = L.validate_doc(doc(VERSE + VERSE), "x.json")
+        self.assertEqual(errors, [])
+        self.assertTrue(any("繰り返し" in w for w in warnings))
+
+    def test_validate_doc_is_quiet_for_normal_body(self):
+        errors, warnings = L.validate_doc(doc(VERSE), "x.json")
+        self.assertEqual(errors, [])
+        self.assertFalse(any("繰り返し" in w for w in warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
develop に直接反映済み (200bf55) のため閉じた。
内容: 劇星☆戦隊ドラスターズの歌詞が同じ本文 2 回分 (200 行) になっていたのを前半 68 行に戻して再投入し、`lyrics_json.py validate` に本文の二重化警告 (`is_doubled_body`) を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)